### PR TITLE
Add a PowerShell Script for Monitoring Unqouted Service Paths in Windows

### DIFF
--- a/PowerShell/Monitors/check-unqouted-service-paths.ps1
+++ b/PowerShell/Monitors/check-unqouted-service-paths.ps1
@@ -1,0 +1,37 @@
+# -----------------------------------------------------------------------------
+# This script is provided as a convenience for Level.io customers. We cannot 
+# guarantee this will work in all environments. Please test before deploying
+# to your production environment.  We welcome contribution to the scripts in 
+# our community repo!
+# -----------------------------------------------------------------------------
+#
+# -----------------------------------------------------------------------------
+# Script Configuration
+# -----------------------------------------------------------------------------
+# Name: Windows Monitor - Check for Unqouted Service Paths
+# Description: Search Windows Services and identify any services that contain 
+# spaces in the path, but no double quotes. Unqouted Service paths create a 
+# privilege escalation vulnerability in windows. See CVE-2023-32658.
+#
+# Language: PowerShell
+# Timeout: 100
+# Version: 1.0
+#
+# -----------------------------------------------------------------------------
+# Monitor Configuration
+# -----------------------------------------------------------------------------
+# Script: Windows Monitor - Check for Unqouted Service Paths
+# Script output: Contains
+# Output value: ALERT
+# Run frequency: Hours
+# Duration: 24
+# -----------------------------------------------------------------------------
+
+# Get Services with a space in the file path, but no double quotes around it.
+$services = Get-WmiObject -Class win32_service -Filter "StartMode='Auto' AND NOT PathName LIKE 'c:\\Windows\\%' AND PathName LIKE '% %' AND NOT PathName LIKE '%`"%'"
+
+# Alert if services are found. 
+if($services -ne $null){
+  Write-Output "ALERT"
+  Exit 1
+}

--- a/PowerShell/Monitors/check-unqouted-service-paths.ps1
+++ b/PowerShell/Monitors/check-unqouted-service-paths.ps1
@@ -32,6 +32,7 @@ $services = Get-WmiObject -Class win32_service -Filter "StartMode='Auto' AND NOT
 
 # Alert if services are found. 
 if($services -ne $null){
-  Write-Output "ALERT"
+  Write-Output "ALERT: The following services are vulnerable to CVE-2023-32658."
+  $services | format-table Name,StartMode,State
   Exit 1
 }


### PR DESCRIPTION
Un-qouted service paths can leave room for privilege escalation vulnerabilities. It is a simple one-line script for the most part to check for the services. I figured it may be a simple addition.

CVSS Score Information: 
https://help.defense.com/en/articles/6302817-microsoft-windows-unquoted-service-path-enumeration-vulnerability

Below is the CVE Information for Intel NUCs:
https://www.cvedetails.com/cve/CVE-2023-32658/